### PR TITLE
Make the `log` feature optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 description = "zk-SNARK library"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/iron-fish/bellman"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]
@@ -19,7 +19,7 @@ ff = "0.12.0"
 group = "0.12.0"
 rand_core = "0.6"
 byteorder = "1"
-log = "0.4.8"
+log = { version = "0.4.8", optional = true }
 rand = { version = "0.8", default-features = false }
 rayon = "1.5.0"
 thiserror = "1.0.10"

--- a/src/groth16/aggregate/prove.rs
+++ b/src/groth16/aggregate/prove.rs
@@ -4,10 +4,10 @@ use std::ops::{AddAssign, MulAssign};
 use blstrs::Compress;
 use ff::{Field, PrimeField};
 use group::{prime::PrimeCurveAffine, Curve};
-use log::{debug, info};
 use rayon::prelude::*;
 use serde::Serialize;
 
+use crate::log::{debug, info};
 use super::{
     commit,
     commit::{VKey, WKey},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,3 +171,32 @@ pub(crate) fn le_bytes_to_u64s(le_bytes: &[u8]) -> Vec<u64> {
         .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
         .collect()
 }
+
+mod log {
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
+    macro_rules! trace {
+        ( $( $tt:tt )* ) => {
+            #[cfg(feature = "log")]
+            ::log::trace!($($tt)*)
+        }
+    }
+
+    macro_rules! debug {
+        ( $( $tt:tt )* ) => {
+            #[cfg(feature = "log")]
+            ::log::debug!($($tt)*)
+        }
+    }
+
+    macro_rules! info {
+        ( $( $tt:tt )* ) => {
+            #[cfg(feature = "log")]
+            ::log::info!($($tt)*)
+        }
+    }
+
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
+    pub(crate) use trace;
+    pub(crate) use debug;
+    pub(crate) use info;
+}


### PR DESCRIPTION
This crate creates some debug logs that show timings of various operations, based on `std::time::Instant`. However `Instant` is not supported on all WASM targets. The purpose of this commit is to make uses of `Instant` optional, so that WASM targets can avoid it.

# Example failure

```
    error output:
        panicked at library/std/src/sys/wasm/../unsupported/time.rs:13:9:
        time not implemented on this platform
        
        Stack:
        
        __wbg_get_imports/imports.wbg.__wbg_new_abda76e883ba8a5f/<@http://127.0.0.1:43495/wasm-bindgen-test:3819:21
        logError@http://127.0.0.1:43495/wasm-bindgen-test:227:18
        __wbg_get_imports/imports.wbg.__wbg_new_abda76e883ba8a5f@http://127.0.0.1:43495/wasm-bindgen-test:3818:66
        console_error_panic_hook::Error::new::ha895460b58f656cf@http://127.0.0.1:43495/wasm-bindgen-test_bg.wasm:wasm-function[10672]:0x4ae6d2
        console_error_panic_hook::hook_impl::hff45ab73e36701d9@http://127.0.0.1:43495/wasm-bindgen-test_bg.wasm:wasm-function[2749]:0x347515
        console_error_panic_hook::hook::h569f615476cbd74c@http://127.0.0.1:43495/wasm-bindgen-test_bg.wasm:wasm-function[13106]:0x4d3b04
        wasm_bindgen_test::__rt::Context::new::{{closure}}::{{closure}}::h9fc3101e9a2bf6b9@http://127.0.0.1:43495/wasm-bindgen-test_bg.wasm:wasm-function[7856]:0x46c65f
        std::panicking::rust_panic_with_hook::h1e6ac5d404b8e31b@http://127.0.0.1:43495/wasm-bindgen-test_bg.wasm:wasm-function[5388]:0x40470b
        std::panicking::begin_panic_handler::{{closure}}::h24b0f4622f2766a5@http://127.0.0.1:43495/wasm-bindgen-test_bg.wasm:wasm-function[6845]:0x448719
        std::sys_common::backtrace::__rust_end_short_backtrace::h19f35d272c126e7c@http://127.0.0.1:43495/wasm-bindgen-test_bg.wasm:wasm-function[15473]:0x4e94f7
        rust_begin_unwind@http://127.0.0.1:43495/wasm-bindgen-test_bg.wasm:wasm-function[11733]:0x4c076f
        core::panicking::panic_fmt::h87755523850ece9e@http://127.0.0.1:43495/wasm-bindgen-test_bg.wasm:wasm-function[12838]:0x4d0462
        std::time::Instant::now::hfc894493361fc7e1@http://127.0.0.1:43495/wasm-bindgen-test_bg.wasm:wasm-function[12833]:0x4d031e
        ironfish_bellperson::groth16::prover::synthesize_circuits_batch::h2de5f22cae1f5fcc@http://127.0.0.1:43495/wasm-bindgen-test_bg.wasm:wasm-function[248]:0x162120
```